### PR TITLE
Bug Fix

### DIFF
--- a/mainstay_connect/connect.py
+++ b/mainstay_connect/connect.py
@@ -69,7 +69,7 @@ class MainstayConnect:
             APIToken abcd1234xyz
         """
         token = keyring.get_password(self.service_name, 'api_token')
-        if token is None:
+        if not token:
             token = input("Enter the API token: ")
             keyring.set_password(self.service_name, 'api_token', token)
         return token


### PR DESCRIPTION
Specifying that the token must not be `None` is too strict. The keyring may return an empty string for new users, which does not prompt the user for a token.

Changing to `if not token` is more Pythonic.